### PR TITLE
Issue 6: Raspberry Pi/Flight Controller Communication

### DIFF
--- a/scripts/mavlink_test.cpp
+++ b/scripts/mavlink_test.cpp
@@ -1,0 +1,46 @@
+#include <mavsdk/component_type.h>
+#include <mavsdk/mavsdk.h>
+#include <iostream>
+#include <chrono>
+#include <string>
+#include <thread>
+
+int main(int argc, char** argv) {
+    mavsdk::Mavsdk mav{mavsdk::Mavsdk::Configuration{mavsdk::ComponentType::GroundStation}};
+
+    // Connection string (e.g., "udp://:14540" for PX4 SITL)
+    std::string connection_url = "serial:///dev/ttyAMA0:57600";
+    if (argc == 2) {
+        connection_url = argv[1];
+    }
+
+    // Add connection 
+    mavsdk::ConnectionResult connection_result = mav.add_any_connection(connection_url);
+    if (connection_result != mavsdk::ConnectionResult::Success) {
+        std::cerr << "Connection failed: " << connection_result << std::endl;
+        return 1;
+    }
+
+    // Wait for system to connect
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    // Check if any systems are connected
+    if (mav.systems().size() == 0) {
+        std::cerr << "No systems connected." << std::endl;
+        return 1;
+    }
+
+    // Get the first connected system
+    auto system = mav.systems()[0];
+
+    // Check if the system is connected
+    if (!system->is_connected()) {
+        std::cerr << "System is not connected." << std::endl;
+        return 1;
+    }
+
+    // Print connection success message
+    std::cout << "Connected to system" << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
## Problem

The `Raspberry Pi` microcomputer in our system will be partially responsible for autonomous control of the drone during periods of its flight, and is fully responsible for making flight decisions based on data processed from the camera frames. As such, the `Raspberry Pi` must be able to communicate with the `Pixhawk 6C Flight Controller` we are using, via `MavLink` over a `serial connection`.

## Solution

Set up `MAVSDK` on the `Raspberry Pi`, and wrote a small test script `mavlink_test.cpp` to test serial connection between `Raspberry Pi` and `Pixhawk 6C Flight Controller`.

## Testing

Tested that `Raspberry Pi` was able to connect to `FC` via test script, and through `QGroundControl`.

Issue: https://github.com/ameall/DRIFT_FW/issues/6