### PR TITLE
Issue #7: CV Algorithm Running on Raspberry Pi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/tracking"]
+	path = src/tracking
+	url = git@github.com:jlevis10/drift-tracking.git


### PR DESCRIPTION
## Problem

One fo the critical tasks performed by the `Raspberry Pi` is to route and process image data from the camera. We have a `CV` function to test vehicle detection and a test script for said function, however this exists as a separate package from this firmware package.

## Solution

Import the [CV repo](https://github.com/jlevis10/drift-tracking) as a submodule into this repo so that we can access the CV function and related test script. Some configuration files for the CV model are also required, which we should ensure are uploaded to the CV repo.

Also install `opencv4` on the `Raspberry Pi` so that we can build and run the `CV` algorithm.

## Testing

Build and ran `CV` test script on `Raspberry Pi`.

Issue: https://github.com/ameall/DRIFT_FW/issues/7